### PR TITLE
Feedback Feature #11914 Add JSON-API Basic support to the project

### DIFF
--- a/src/main/java/ca/gc/aafc/seqdb/api/repository/handlers/SelectionHandler.java
+++ b/src/main/java/ca/gc/aafc/seqdb/api/repository/handlers/SelectionHandler.java
@@ -58,13 +58,14 @@ public class SelectionHandler {
       selectedFieldsOfThisClass.addAll(
           resourceInformation.getRelationshipFields()
               .stream()
+              .filter(field -> !field.isCollection())
               // Map each ResourceField to the attribute path of the related resource's ID, e.g.
               // ["region","id"].
               .map(field -> {
                 List<String> relationIdPath = new ArrayList<>();
                 // Add the field name to the attribute path e.g. "region"
                 relationIdPath.add(field.getUnderlyingName());
-                // Add the ID field name tot he attribute path e.g. "id"
+                // Add the ID field name to the attribute path e.g. "id"
                 relationIdPath.add(
                     resourceRegistry.findEntry(field.getElementType())
                         .getResourceInformation()

--- a/src/test/java/ca/gc/aafc/seqdb/api/repository/JpaResourceRepositoryTest.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/repository/JpaResourceRepositoryTest.java
@@ -5,12 +5,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.Comparators;
 
+import ca.gc.aafc.seqdb.api.dto.PcrBatchDto;
 import ca.gc.aafc.seqdb.api.dto.PcrPrimerDto;
 import ca.gc.aafc.seqdb.api.dto.RegionDto;
 import ca.gc.aafc.seqdb.entities.PcrPrimer;
@@ -27,6 +29,7 @@ public class JpaResourceRepositoryTest extends BaseRepositoryTest {
 
   private ResourceRepositoryV2<PcrPrimerDto, Serializable> primerRepository;
   private ResourceRepositoryV2<RegionDto, Serializable> regionRepository;
+  private ResourceRepositoryV2<PcrBatchDto, Serializable> pcrBatchRepository;
 
   /**
    * Get the repository facade from crnk, which will invoke all filters, decorators, etc.
@@ -36,6 +39,8 @@ public class JpaResourceRepositoryTest extends BaseRepositoryTest {
     this.primerRepository = this.resourceRegistry.getEntry(PcrPrimerDto.class)
         .getResourceRepositoryFacade();
     this.regionRepository = this.resourceRegistry.getEntry(RegionDto.class)
+        .getResourceRepositoryFacade();
+    this.pcrBatchRepository = this.resourceRegistry.getEntry(PcrBatchDto.class)
         .getResourceRepositoryFacade();
   }
 
@@ -149,6 +154,22 @@ public class JpaResourceRepositoryTest extends BaseRepositoryTest {
   @Test(expected = ResourceNotFoundException.class)
   public void findOnePrimer_onPrimerNotFound_throwsResourceNotFoundException() {
     primerRepository.findOne(1, new QuerySpec(PcrPrimerDto.class));
+  }
+  
+  @Test
+  public void findAll_whenNoSortSpecified_resultsAreUniqueAndSortedByAscendingId() {
+    for (int i = 1; i <= 10; i++) {
+      this.persistTestPcrBatchWith22Reactions("test batch " + i);
+    }
+    
+    QuerySpec querySpec = new QuerySpec(PcrBatchDto.class);
+    querySpec.setLimit(Long.valueOf(10));
+    ResourceList<PcrBatchDto> batchDtos = pcrBatchRepository.findAll(querySpec);
+    
+    assertEquals(
+        IntStream.range(1, 11).boxed().collect(Collectors.toList()),
+        batchDtos.stream().map(PcrBatchDto::getPcrBatchId).collect(Collectors.toList())
+    );
   }
   
   @Test


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/11914

Fixed a bug that was affecting the pcr batch resource repository:
-When no fields are specified for a search, SelectionHandler was
creating a join on the "reactions" field, which was causing duplicate
results because joining on reactions will return a copy of the pcr batch
row for each related reaction.
-I solved this by filtering the automatically included relationship
fields to just the to-one fields.
-I wrote a test for this fix called
"findAll_whenNoSortSpecified_resultsAreUniqueAndSortedByAscendingId"
which checks that the IDs of the batches returned are 1 to 10 when the
limit is 10 and no sort is specified.