### PR TITLE
Feedback Support #11913 Prepare Integration Tests structure and base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,5 +71,14 @@
     </dependency>
     
   </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/src/test/java/ca/gc/aafc/seqdb/api/AppStartsIT.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/AppStartsIT.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
     properties = "server.port=8080"
 )
-public class AppStartsTest extends BaseIntegrationTest {
+public class AppStartsIT extends BaseIntegrationTest {
 
   /**
    * Tests that the application with embedded Tomcat starts up successfully.


### PR DESCRIPTION
classes

https://redmine.biodiversity.agr.gc.ca/issues/11913

-Enabled the failsafe plugin.
-RenamedAppstartsTest to AppStartsIT so it is run by failsafe instead of
surefire.