### PR TITLE
Feedback Feature #13461 Complete PcrPrimer entity support

### DIFF
--- a/src/main/java/ca/gc/aafc/seqdb/api/dto/PcrPrimerDto.java
+++ b/src/main/java/ca/gc/aafc/seqdb/api/dto/PcrPrimerDto.java
@@ -1,5 +1,8 @@
 package ca.gc.aafc.seqdb.api.dto;
 
+import java.sql.Timestamp;
+import java.util.Date;
+
 import ca.gc.aafc.seqdb.entities.PcrPrimer.PrimerType;
 import io.crnk.core.resource.annotations.JsonApiId;
 import io.crnk.core.resource.annotations.JsonApiRelation;
@@ -13,6 +16,8 @@ public class PcrPrimerDto {
   @JsonApiId
   private Integer pcrPrimerId;
 
+  // Required fields
+
   private String name;
 
   private PrimerType type;
@@ -21,7 +26,68 @@ public class PcrPrimerDto {
 
   private Integer lotNumber;
 
+  // Optional fields
+
+  private Integer version;
+
+  private Date designDate;
+
+  private String direction;
+
+  private String tmCalculated;
+
+  private Integer tmPe;
+
+  private String position;
+
+  private String storage;
+
+  private String restrictionSite;
+
+  private Boolean used4sequencing;
+
+  private Boolean used4qrtpcr;
+
+  private Boolean used4nestedPcr;
+
+  private Boolean used4genotyping;
+
+  private Boolean used4cloning;
+
+  private Boolean used4stdPcr;
+
+  private String referenceSeqDir;
+
+  private String referenceSeqFile;
+
+  private String urllink;
+
+  private String note;
+
+  private Timestamp lastModified;
+
+  private String application;
+
+  private String reference;
+
+  private String targetSpecies;
+
+  private String supplier;
+
+  private Date dateOrdered;
+
+  private String purification;
+
+  private String designedBy;
+
+  private String stockConcentration;
+
+  // Optional relations
+
   @JsonApiRelation
   private RegionDto region;
+
+  @JsonApiRelation
+  private GroupDto group;
 
 }


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/13461

-Added the rest of the fields to PcrPrimerDto, excluding seqLength
because it should be derived from seq by the API's client if that value
is needed.
-Added the  "group" relation to PcrPrimerDto.