### PR TITLE
Feedback Support #13566 Improve test coverage

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/ca/gc/aafc/seqdb/api/repository/JpaDtoRepository.java
+++ b/src/main/java/ca/gc/aafc/seqdb/api/repository/JpaDtoRepository.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -40,7 +39,6 @@ import io.crnk.core.engine.information.resource.ResourceField;
 import io.crnk.core.engine.information.resource.ResourceInformation;
 import io.crnk.core.engine.internal.utils.PropertyUtils;
 import io.crnk.core.engine.registry.ResourceRegistry;
-import io.crnk.core.exception.ResourceNotFoundException;
 import io.crnk.core.queryspec.Direction;
 import io.crnk.core.queryspec.QuerySpec;
 import io.crnk.core.resource.list.DefaultResourceList;
@@ -184,18 +182,16 @@ public class JpaDtoRepository {
   }
 
   /**
-   * Delete a JPA entity.
-   * @param dtoClass the JPA entity's DTO class
-   * @param id the entity's ID
+   * Deletes a JPA entity given a DTO.
+   * 
+   * @param resource the resource DTO to be deleted.
+   * @param resourceRegistry the Crnk ResourceRegistry.
    */
-  public void delete(Class<?> dtoClass, Serializable id) {
+  public void delete(Object resource, ResourceRegistry resourceRegistry) {
     Object entity = entityManager.find(
-        this.dtoJpaMapper.getEntityClassForDto(dtoClass),
-        id
+        this.dtoJpaMapper.getEntityClassForDto(resource.getClass()),
+        resourceRegistry.findEntry(resource.getClass()).getResourceInformation().getId(resource)
     );
-    if (entity == null) {
-      throw new ResourceNotFoundException("Resource not found");
-    }
     entityManager.remove(entity);
   }
 

--- a/src/main/java/ca/gc/aafc/seqdb/api/repository/JpaResourceRepository.java
+++ b/src/main/java/ca/gc/aafc/seqdb/api/repository/JpaResourceRepository.java
@@ -131,7 +131,10 @@ public class JpaResourceRepository<D>
 
   @Override
   public void delete(Serializable id) {
-    this.dtoRepository.delete(this.resourceClass, id);
+    this.dtoRepository.delete(
+        this.findOne(id, new QuerySpec(this.resourceClass)),
+        this.resourceRegistry
+    );
   }
 
 }

--- a/src/test/java/ca/gc/aafc/seqdb/api/security/ImportSampleAccountsIT.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/security/ImportSampleAccountsIT.java
@@ -1,0 +1,73 @@
+package ca.gc.aafc.seqdb.api.security;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+import ca.gc.aafc.seqdb.api.BaseIntegrationTest;
+import ca.gc.aafc.seqdb.api.security.SecurityRepositories.AccountRepository;
+import ca.gc.aafc.seqdb.entities.Account;
+import ca.gc.aafc.seqdb.entities.AccountsGroup;
+import ca.gc.aafc.seqdb.entities.Group;
+
+@RunWith(Enclosed.class)
+public class ImportSampleAccountsIT {
+
+  @TestPropertySource(properties="import-sample-accounts=true")
+  public static class ImportSampleAccountsEnabledIT extends BaseIntegrationTest {
+    
+    @Inject
+    private AccountRepository accountRepository;
+    
+    @Inject
+    private PasswordEncoder passwordEncoder;
+    
+    @Test
+    public void startApp_whenImportSampleAccountsTrue_sampleAccountsAvailable() {
+      // Check Admin account data
+      Account adminAccount = accountRepository.findByAccountNameIgnoreCase("admin");
+      assertTrue(passwordEncoder.matches("Admin", adminAccount.getAccountPw()));
+      assertEquals("Admin", adminAccount.getAccountType());
+      assertEquals("Active", adminAccount.getAccountStatus());
+      
+      AccountsGroup adminPermission = adminAccount.getAccountsGroups().iterator().next();
+      assertEquals("1111", adminPermission.getRights());
+      assertEquals(Boolean.TRUE, adminPermission.getAdmin());
+      
+      Group adminGroup = adminPermission.getGroup();
+      assertEquals("Admin", adminGroup.getGroupName());
+      
+      // Check User account data
+      Account userAccount = accountRepository.findByAccountNameIgnoreCase("user");
+      assertTrue(passwordEncoder.matches("User", userAccount.getAccountPw()));
+      assertEquals("User", userAccount.getAccountType());
+      assertEquals("Active", userAccount.getAccountStatus());
+      
+      AccountsGroup userPermission = userAccount.getAccountsGroups().iterator().next();
+      assertEquals("1111", userPermission.getRights());
+      assertEquals(Boolean.TRUE, userPermission.getAdmin());
+      
+      Group userGroup = userPermission.getGroup();
+      assertEquals("User", userGroup.getGroupName());
+    }
+    
+  }
+  
+  public static class ImportSampleAccountsDisabledIT extends BaseIntegrationTest {
+    
+    @Inject
+    private AccountRepository accountRepository;
+    
+    @Test
+    public void startApp_whenImportSampleAccountsNotSet_sampleAccountsNotAvailable() {
+      assertNull(this.accountRepository.findByAccountNameIgnoreCase("Admin"));
+      assertNull(this.accountRepository.findByAccountNameIgnoreCase("User"));
+    }
+    
+  }
+  
+}

--- a/src/test/java/ca/gc/aafc/seqdb/api/security/SeqdbDaoAuthenticationProviderIT.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/security/SeqdbDaoAuthenticationProviderIT.java
@@ -20,7 +20,7 @@ public class SeqdbDaoAuthenticationProviderIT extends BaseIntegrationTest {
   private PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
   
   @Test
-  public void localAuth_whenCorrectCredentialsAreGiven_noExceptionThrown() {
+  public void localAuth_whenCorrectCredentialsAreGiven_returnsAuthentication() {
     Account testAccount = new Account();
     testAccount.setAccountName("Mat");
     testAccount.setAccountType("User");
@@ -29,7 +29,21 @@ public class SeqdbDaoAuthenticationProviderIT extends BaseIntegrationTest {
     
     // This lookup should be case-insensitive
     Authentication authToken = new UsernamePasswordAuthenticationToken("mat", "mypassword");
-    authenticationProvider.authenticate(authToken);
+    assertTrue(authenticationProvider.authenticate(authToken) instanceof Authentication);
+  }
+  
+  @Test
+  public void ldapAuth_whenCorrectCredentialsAreGivenWithLdapDn_returnsNull() {
+    Account testAccount = new Account();
+    testAccount.setAccountName("Mat");
+    testAccount.setAccountType("User");
+    testAccount.setAccountPw(passwordEncoder.encode("mypassword"));
+    testAccount.setLdapDn("testLdapDn");
+    entityManager.persist(testAccount);
+    
+    // This lookup should be case-insensitive
+    Authentication authToken = new UsernamePasswordAuthenticationToken("mat", "mypassword");
+    assertNull(authenticationProvider.authenticate(authToken));
   }
   
   @Test(expected = BadCredentialsException.class)


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/13566

Added new tests:
-setRelation_whenPcrReactionIsMovedToDifferentBatch_reactionEntiityRelatedBatchIsChanged
-setRelationPcrReactionToPcrBatch_whenReactionAlreadyLinkedToBatch_relationDoesNotChange
-ImportSampleAccountsIT

-Rewrote delete method to call findOne, instead of throwing its own
ResourceNotFoundException, which was not covered during tests because
GroupAuthorizationAspect called findOne first.

-Added lombok.config so that Jacoco will ignore lombok-generated code.