### PR TITLE
Feedback Bug #15474 Some RSQL filters fail

### DIFF
--- a/src/test/java/ca/gc/aafc/seqdb/api/repository/filter/RsqlFilterHandlerIT.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/repository/filter/RsqlFilterHandlerIT.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 
 import javax.inject.Inject;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import ca.gc.aafc.seqdb.api.dto.PcrPrimerDto;
@@ -21,15 +22,18 @@ public class RsqlFilterHandlerIT extends BaseRepositoryTest {
   @Inject
   private ResourceRepositoryV2<PcrPrimerDto, Serializable> primerRepository;
   
-  @Test
-  public void findAllPrimers_whenRsqlFilterIsSet_filteredPrimersAreReturned() {
+  @Before
+  public void initPrimers() {
     // Persist 5 test primers.
     persist(PcrPrimerFactory.newPcrPrimer().name("primer1").build());
     persist(PcrPrimerFactory.newPcrPrimer().name("primer2").build());
     persist(PcrPrimerFactory.newPcrPrimer().name("primer3").build());
     persist(PcrPrimerFactory.newPcrPrimer().name("primer4").build());
     persist(PcrPrimerFactory.newPcrPrimer().name("primer5").build());
-    
+  }
+  
+  @Test
+  public void findAllPrimers_whenRsqlFilterIsSet_filteredPrimersAreReturned() {
     // Filter by name = "primer2" or name = "primer4".
     QuerySpec querySpec = new QuerySpec(PcrPrimerDto.class);
     querySpec.setFilters(
@@ -38,6 +42,45 @@ public class RsqlFilterHandlerIT extends BaseRepositoryTest {
                 Collections.singletonList("rsql"),
                 FilterOperator.EQ,
                 "name==primer2 or name==primer4" // RSQL string
+            )
+        )
+    );
+    
+    // Check that the 2 primers were returned.
+    ResourceList<PcrPrimerDto> primers = this.primerRepository.findAll(querySpec);
+    assertEquals(2, primers.size());
+    assertEquals("primer2", primers.get(0).getName());
+    assertEquals("primer4", primers.get(1).getName());
+  }
+  
+  @Test
+  public void findAllPrimers_whenRqslFilterIsBlank_allPrimersAreReturned() {
+    // Filter by name = "primer2" or name = "primer4".
+    QuerySpec querySpec = new QuerySpec(PcrPrimerDto.class);
+    querySpec.setFilters(
+        Collections.singletonList(
+            new FilterSpec(
+                Collections.singletonList("rsql"),
+                FilterOperator.EQ,
+                "" // Blank RSQL string
+            )
+        )
+    );
+    
+    ResourceList<PcrPrimerDto> primers = this.primerRepository.findAll(querySpec);
+    assertEquals(5, primers.size());
+  }
+  
+  @Test
+  public void findAllPrimers_whenRsqlFilterHasCommas_filteredPrimersAreReturned() {
+    // Filter by name = "primer2" or name = "primer4".
+    QuerySpec querySpec = new QuerySpec(PcrPrimerDto.class);
+    querySpec.setFilters(
+        Collections.singletonList(
+            new FilterSpec(
+                Collections.singletonList("rsql"),
+                FilterOperator.EQ,
+                "name==primer2,name==primer4" // RSQL string
             )
         )
     );


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/15474

-Added check to ignore blank rsql strings.
-Added workaround for Crnk's splitting of comma-containing rsql strings
into HashSets.
-Added tests to prove the bugs were fixed.