### PR TITLE
Feedback Support #14909 persisted dates are behind by 1 day

### DIFF
--- a/src/main/java/ca/gc/aafc/seqdb/api/json/DateDeserializer.java
+++ b/src/main/java/ca/gc/aafc/seqdb/api/json/DateDeserializer.java
@@ -1,0 +1,44 @@
+package ca.gc.aafc.seqdb.api.json;
+
+import java.io.IOException;
+import java.sql.Date;
+
+import org.springframework.boot.jackson.JsonComponent;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import io.crnk.core.engine.document.ErrorData;
+import io.crnk.core.engine.http.HttpStatus;
+import io.crnk.core.exception.CrnkMappableException;
+
+/**
+ * Deserializer for ObjectMapper that converts a string of YYYY-MM-DD format to a java.sql.date.
+ */
+@JsonComponent
+public class DateDeserializer extends JsonDeserializer<Date>{
+
+  private static final Integer STATUS_ON_ERROR = HttpStatus.UNPROCESSABLE_ENTITY_422;
+  
+  @Override
+  public Date deserialize(JsonParser parser, DeserializationContext ctxt)
+      throws IOException, JsonProcessingException {
+    String text = parser.getText();
+    try {
+      return Date.valueOf(text);
+    } catch(IllegalArgumentException e) {
+      ErrorData errorData = ErrorData.builder()
+          .setStatus(STATUS_ON_ERROR.toString())
+          .setTitle("Date format error")
+          .setDetail(String.format("\"%s\": The date given is not in the JDBC date escape format (yyyy-[m]m-[d]d).", text))
+          .build();
+      
+      throw new CrnkMappableException(STATUS_ON_ERROR, errorData, e) {
+        private static final long serialVersionUID = 8177279204226674938L;
+      };
+    }
+  }
+
+}

--- a/src/test/java/ca/gc/aafc/seqdb/api/json/DateDeserializerIT.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/json/DateDeserializerIT.java
@@ -1,0 +1,59 @@
+package ca.gc.aafc.seqdb.api.json;
+
+import java.io.IOException;
+import java.sql.Date;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ca.gc.aafc.seqdb.api.BaseIntegrationTest;
+import io.crnk.core.engine.document.ErrorData;
+import io.crnk.core.exception.CrnkMappableException;
+import lombok.Data;
+
+public class DateDeserializerIT extends BaseIntegrationTest {
+
+  @Inject
+  private ObjectMapper objectMapper;
+  
+  /**
+   * Test class for deserializing a date.
+   */
+  @Data
+  private static class DateWrapper {
+    private Date date;
+  }
+  
+  @Test
+  public void parseDate_whenDateIsValid_dateIsDeserialized() throws JsonParseException, JsonMappingException, IOException {
+    String jsonDateWrapper = "{\"date\": \"2019-03-27\"}";
+    DateWrapper dateWrapper = objectMapper.readValue(jsonDateWrapper, DateWrapper.class);
+    assertEquals("2019-03-27", dateWrapper.getDate().toString());
+  }
+  
+  @Test
+  public void parseDate_whenDateIsInvalid_ExceptionIsThrown() throws JsonParseException, JsonMappingException, IOException {
+    String jsonDateWrapper = "{\"date\": \"bad value\"}";
+    try {
+      objectMapper.readValue(jsonDateWrapper, DateWrapper.class);
+      fail("Exception not thrown.");
+    } catch(JsonMappingException exception) {
+      CrnkMappableException cause = (CrnkMappableException) exception.getCause();
+      assertEquals(422, cause.getHttpStatus());
+      assertEquals("\"bad value\": The date given is not in the JDBC date escape format (yyyy-[m]m-[d]d).", cause.getMessage());
+      
+      ErrorData error = cause.getErrorData();
+      
+      // Assert correct error message, status and title
+      assertEquals("\"bad value\": The date given is not in the JDBC date escape format (yyyy-[m]m-[d]d).", error.getDetail());
+      assertEquals("422", error.getStatus());
+      assertEquals("Date format error", error.getTitle());
+    }
+  }
+  
+}


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/14909

-Added custom DateDeserializer to convert a string to a java.sql.Date.
This fixes the issue where the API reduces submitted dates by 1 day.