### PR TITLE
Feedback Bug #15701 RSQL filters with commas failing again

### DIFF
--- a/src/main/java/ca/gc/aafc/seqdb/api/ResourceRepositoryConfig.java
+++ b/src/main/java/ca/gc/aafc/seqdb/api/ResourceRepositoryConfig.java
@@ -11,6 +11,7 @@ import javax.persistence.criteria.Path;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 
 import ca.gc.aafc.seqdb.api.dto.GroupDto;
 import ca.gc.aafc.seqdb.api.dto.PcrBatchDto;
@@ -32,9 +33,13 @@ import ca.gc.aafc.seqdb.entities.PcrPrimer;
 import ca.gc.aafc.seqdb.entities.PcrReaction;
 import ca.gc.aafc.seqdb.entities.Product;
 import ca.gc.aafc.seqdb.entities.Region;
+import io.crnk.core.queryspec.mapper.DefaultQuerySpecUrlMapper;
 
 @Configuration
 @EntityScan("ca.gc.aafc.seqdb.entities")
+// Must explicitly depend on "querySpecUrlMapper" so Spring can inject it into this class'
+// initQuerySpecUrlMapper method.
+@DependsOn("querySpecUrlMapper")
 public class ResourceRepositoryConfig {
 
   @Inject
@@ -48,6 +53,13 @@ public class ResourceRepositoryConfig {
   
   @Inject
   private ReadableGroupFilterHandlerFactory groupFilterFactory;
+  
+  @Inject
+  public void initQuerySpecUrlMapper(DefaultQuerySpecUrlMapper mapper) {
+    // Disables Crnk's behavior of splitting up query params that contain commas into HashSets.
+    // This will allow RSQL 'OR' filters like "name==primer2,name==primer4".
+    mapper.setAllowCommaSeparatedValue(false);
+  }
   
   /**
    * Configures DTO-to-Entity mappings.

--- a/src/main/java/ca/gc/aafc/seqdb/api/repository/filter/RsqlFilterHandler.java
+++ b/src/main/java/ca/gc/aafc/seqdb/api/repository/filter/RsqlFilterHandler.java
@@ -1,7 +1,5 @@
 package ca.gc.aafc.seqdb.api.repository.filter;
 
-import java.util.HashSet;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.EntityManager;
@@ -43,15 +41,7 @@ public class RsqlFilterHandler implements FilterHandler {
       return cb.and();
     }
     
-    // Crnk provides a filter value which could be a string or a HashSet.
-    Object crnkRsqlValue = rsqlFilterSpec.getValue();
-    
-    String rsqlString = crnkRsqlValue instanceof String ? (String) crnkRsqlValue
-        // Crnk may provide a HashSet if an RSQL filter containing a comma was requested.
-        // e.g. filter[rsql]=name==101f,group.groupName==poffm
-        // Commas in RSQL should be treated as "OR" operators, but Crnk splits these queries into multiple strings.
-        // We want the comma-containing filters to remain intact, so we re-join the RSQL strings here.
-        : StringUtils.joinWith(",", ((HashSet<String>) crnkRsqlValue).toArray());
+    String rsqlString = rsqlFilterSpec.getValue();
     
     return rsqlParser.parse(rsqlString)
         .accept(new JpaPredicateVisitor<>().defineRoot(root), entityManager);


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/15701

-Added @DependsOn annotation to ResourceRepositoryConfig so the
DefaultQuerySpecUrlMapper is injected.
-Removed previous fix from RsqlFilterHandler.
-Added DefaultQuerySpecUrlMapper config to ResourceRepositoryConfig.
-Added new test for DefaultQuerySpecUrlMapper.