### PR TITLE
Support #16283 Remove oraclejdk8 from travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 script: mvn verify
 
 jdk:
-  - oraclejdk8
   - openjdk8
   - openjdk9
-
+  - openjdk10


### PR DESCRIPTION
Replaced oraclejdk8 by openjdk10