### PR TITLE
Support #16803 - Omit "links" fields from JSONAPI responses

### DIFF
--- a/src/main/java/ca/gc/aafc/seqdb/api/repository/jpa/JpaDtoRepository.java
+++ b/src/main/java/ca/gc/aafc/seqdb/api/repository/jpa/JpaDtoRepository.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Streams;
 
 import ca.gc.aafc.seqdb.api.repository.handlers.JpaDtoMapper;
 import ca.gc.aafc.seqdb.api.repository.handlers.SelectionHandler;
+import ca.gc.aafc.seqdb.api.repository.links.NoLinkInformation;
 import ca.gc.aafc.seqdb.api.repository.meta.JpaMetaInformationProvider;
 import ca.gc.aafc.seqdb.api.repository.meta.JpaMetaInformationProvider.JpaMetaInformationParams;
 import ca.gc.aafc.seqdb.interfaces.UniqueObj;
@@ -67,6 +68,9 @@ public class JpaDtoRepository {
   @NonNull
   @Getter
   private final JpaDtoMapper dtoJpaMapper;
+  
+  /* Forces CRNK to not display any top-level links. */
+  private static final NoLinkInformation NO_LINK_INFORMATION = new NoLinkInformation();
 
   private static final ObjectMapper MAPPER = new ObjectMapper()
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -138,7 +142,7 @@ public class JpaDtoRepository {
         metaInformationProvider.getMetaInformation(
             JpaMetaInformationParams.builder().sourceResourceClass(sourceDtoClass)
                 .customRoot(customRoot).customFilter(customFilter).build()),
-        null);
+        NO_LINK_INFORMATION);
   }
 
   /**

--- a/src/main/java/ca/gc/aafc/seqdb/api/repository/links/NoLinkInformation.java
+++ b/src/main/java/ca/gc/aafc/seqdb/api/repository/links/NoLinkInformation.java
@@ -1,0 +1,13 @@
+package ca.gc.aafc.seqdb.api.repository.links;
+
+import io.crnk.core.resource.links.LinksInformation;
+
+/**
+ * Since CRNK does not have a way not to display links in API responses, this class will serve the
+ * purpose of not showing any information in the links.
+ * 
+ * This is just used to remove the top-level links. To remove the other links in a response you will
+ * need to use the crnk-compact header.
+ */
+public class NoLinkInformation implements LinksInformation {
+}


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/16803

- Top-level links are removed from the API responses since they are no
longer needed. To remove other "link" fields you will need to use the
crnk-compact header.