### PR TITLE
Support #17084 - Remove TestProperty annotation for importing sample

### DIFF
--- a/src/test/java/ca/gc/aafc/seqdb/api/BaseHttpIntegrationTest.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/BaseHttpIntegrationTest.java
@@ -1,13 +1,42 @@
 package ca.gc.aafc.seqdb.api;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
-@SpringBootTest(
-    classes = SeqdbApiLauncher.class,
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
-)
-public abstract class BaseHttpIntegrationTest extends BaseIntegrationTest { 
+import ca.gc.aafc.seqdb.api.security.ImportSampleAccounts;
+
+/**
+ * This base class for http based will start a test web server on a random port (available in
+ * testPost variable). Sample accounts are also inserted and committed into the test database to
+ * make sure tests can connect using them.
+ *
+ */
+@SpringBootTest(classes = SeqdbApiLauncher.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class BaseHttpIntegrationTest extends BaseIntegrationTest {
+
+  private static final AtomicBoolean initialized = new AtomicBoolean(false);
+
   @LocalServerPort
   protected int testPort;
+
+  @Autowired
+  private PasswordEncoder passwordEncoder;
+
+  @BeforeEach
+  public void setupAccounts() {
+    // we only need it once for all classes
+    if (initialized.compareAndSet(false, true)) {
+      runInNewTransaction(em -> {
+        ImportSampleAccounts importSampleAccounts = new ImportSampleAccounts(em, passwordEncoder);
+        importSampleAccounts.insertUserAccounts();
+      });
+
+    }
+  }
+
 }

--- a/src/test/java/ca/gc/aafc/seqdb/api/BaseIntegrationTest.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/BaseIntegrationTest.java
@@ -1,13 +1,23 @@
 package ca.gc.aafc.seqdb.api;
 
+import java.util.function.Consumer;
+
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
 import javax.persistence.PersistenceContext;
 
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 
+ * Base class for integration tests working at the database-level.
+ *
+ */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = SeqdbApiLauncher.class)
 @Transactional
@@ -15,5 +25,28 @@ public abstract class BaseIntegrationTest {
 
   @PersistenceContext
   protected EntityManager entityManager;
+  
+  // Should only be used with runInNewTransaction
+  @Autowired
+  private EntityManagerFactory entityManagerFactory;
+  
+  /**
+   * Accepts a {@link Consumer} of {@link EntityManager} that will be called in a new, unmanaged transaction.
+   * The main goal is to not interfere with SpringTest Managed transaction.
+   * Note that the Transaction will be committed.
+   * 
+   * This should only be used for setup/tear down purpose.
+   * 
+   * @param emConsumer
+   */
+  protected void runInNewTransaction(Consumer<EntityManager> emConsumer) {
+    EntityManager em = entityManagerFactory.createEntityManager();
+    EntityTransaction et = em.getTransaction();
+    et.begin();
+    emConsumer.accept(em);
+    em.flush();
+    et.commit();
+    em.close();
+  }
 
 }

--- a/src/test/java/ca/gc/aafc/seqdb/api/TomcatWebServerCustomizerIT.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/TomcatWebServerCustomizerIT.java
@@ -1,6 +1,7 @@
 package ca.gc.aafc.seqdb.api;
 
 import java.io.IOException;
+import javax.persistence.EntityManager;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpHeaders;
@@ -10,10 +11,18 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.Test;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
-@TestPropertySource(properties="import-sample-accounts=true")
+import ca.gc.aafc.seqdb.api.security.ImportSampleAccounts;
+
 public class TomcatWebServerCustomizerIT extends BaseHttpIntegrationTest {
+
+  @Autowired
+  private EntityManager entityManager;
+  
+  @Autowired
+  private PasswordEncoder passwordEncoder;
 
   /**
    * Test to ensure that square brackets are allowed in URLs.
@@ -32,6 +41,11 @@ public class TomcatWebServerCustomizerIT extends BaseHttpIntegrationTest {
   @Test
   public void sendRequestToRegionEndpoint_withAuthentication_statusCode200()
        throws ClientProtocolException, IOException {
+    
+    // Insert the user account for authorization.
+    ImportSampleAccounts importSampleAccounts = new ImportSampleAccounts(entityManager, passwordEncoder);
+    importSampleAccounts.insertUserAccounts();
+    
     HttpClient client = HttpClientBuilder.create().build();
     HttpGet request = new HttpGet("http://localhost:" + testPort + "/api/region?page[limit]=10");
 

--- a/src/test/java/ca/gc/aafc/seqdb/api/TomcatWebServerCustomizerIT.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/TomcatWebServerCustomizerIT.java
@@ -1,7 +1,6 @@
 package ca.gc.aafc.seqdb.api;
 
 import java.io.IOException;
-import javax.persistence.EntityManager;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpHeaders;
@@ -11,20 +10,10 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
-
-import ca.gc.aafc.seqdb.api.security.ImportSampleAccounts;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TomcatWebServerCustomizerIT extends BaseHttpIntegrationTest {
-
-  @Autowired
-  private EntityManager entityManager;
-  
-  @Autowired
-  private PasswordEncoder passwordEncoder;
 
   /**
    * Test to ensure that square brackets are allowed in URLs.
@@ -43,10 +32,6 @@ public class TomcatWebServerCustomizerIT extends BaseHttpIntegrationTest {
   @Test
   public void sendRequestToRegionEndpoint_withAuthentication_statusCode200()
        throws ClientProtocolException, IOException {
-    
-    // Insert the user account for authorization.
-    ImportSampleAccounts importSampleAccounts = new ImportSampleAccounts(entityManager, passwordEncoder);
-    importSampleAccounts.insertUserAccounts();
     
     HttpClient client = HttpClientBuilder.create().build();
     HttpGet request = new HttpGet("http://localhost:" + testPort + "/api/region?page[limit]=10");

--- a/src/test/java/ca/gc/aafc/seqdb/api/rest/BaseJsonApiIntegrationTest.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/rest/BaseJsonApiIntegrationTest.java
@@ -77,17 +77,10 @@ public abstract class BaseJsonApiIntegrationTest extends BaseHttpIntegrationTest
   
   private static final String JSON_SCHEMA_FOLDER = "static/json-schema";
 
-  @Autowired
-  private PasswordEncoder passwordEncoder;
-  
-  private ImportSampleAccounts importSampleAccounts;
-  
+
 	@BeforeEach
 	public final void before() {
-	  // Import the user and admin account for REST authorization. 
-	  importSampleAccounts = new ImportSampleAccounts(entityManager, passwordEncoder);
-	  importSampleAccounts.insertUserAccounts();
-	  
+
 		RestAssured.port = testPort;
 		RestAssured.baseURI = IT_BASE_URI.toString();
 		RestAssured.basePath = API_BASE_PATH;

--- a/src/test/java/ca/gc/aafc/seqdb/api/rest/BaseJsonApiIntegrationTest.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/rest/BaseJsonApiIntegrationTest.java
@@ -15,9 +15,11 @@ import java.util.Map;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.TestPropertySource;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -70,14 +72,22 @@ public abstract class BaseJsonApiIntegrationTest extends BaseHttpIntegrationTest
     IT_OBJECT_MAPPER.setSerializationInclusion(Include.NON_NULL);
   }
 
-  
   public static final String API_BASE_PATH = "/api";
   public static final String SCHEMA_BASE_PATH = "/json-schema";
   
   private static final String JSON_SCHEMA_FOLDER = "static/json-schema";
 
+  @Autowired
+  private PasswordEncoder passwordEncoder;
+  
+  private ImportSampleAccounts importSampleAccounts;
+  
 	@Before
 	public final void before() {
+	  // Import the user and admin account for REST authorization. 
+	  importSampleAccounts = new ImportSampleAccounts(entityManager, passwordEncoder);
+	  importSampleAccounts.insertUserAccounts();
+	  
 		RestAssured.port = testPort;
 		RestAssured.baseURI = IT_BASE_URI.toString();
 		RestAssured.basePath = API_BASE_PATH;

--- a/src/test/java/ca/gc/aafc/seqdb/api/rest/IncludeParamLookupBehaviorIT.java
+++ b/src/test/java/ca/gc/aafc/seqdb/api/rest/IncludeParamLookupBehaviorIT.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.TestPropertySource;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -17,7 +16,6 @@ import io.restassured.RestAssured;
 import io.restassured.authentication.PreemptiveBasicAuthScheme;
 import io.restassured.response.Response;
 
-@TestPropertySource(properties="import-sample-accounts=true")
 public class IncludeParamLookupBehaviorIT extends BaseHttpIntegrationTest {
   
   public static final String JSON_API_CONTENT_TYPE = BaseJsonApiIntegrationTest.JSON_API_CONTENT_TYPE;


### PR DESCRIPTION
accounts

https://redmine.biodiversity.agr.gc.ca/issues/17084

- Removed the @TestPropertySource from three places using it.
- Added the import sample account method to add it for the specific test
then roll back the changes.