### PR TITLE
Support #17095 jacoco update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,6 +424,27 @@
               <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
             </configuration>
           </execution>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+            <dataFile>${project.build.directory}/aggregate.exec</dataFile>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.90</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>


### PR DESCRIPTION
Here is a basic example that requires an overall instruction coverage of 90%.

This measures the aggregate report covering both Unit and IT tests.

You can easily test this by pulling the branch, setting the coverage to 99% and watch it fail.

You can verify the aggerate report generated at ./site/jaco-aggregate/index.html