### PR TITLE
Feedback Support #18020 Update Spring Boot to v2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,7 @@
     <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
     <checkstyle.version>8.18</checkstyle.version>
     <asciidoctor-maven-plugin.version>1.5.7.1</asciidoctor-maven-plugin.version>
-    <!-- rest assured 4.0.0 is required for API testing-->
-    <rest-assured.version>4.0.0</rest-assured.version>
-	<justify.version>0.17.0</justify.version>    
+    <justify.version>0.17.0</justify.version>
 	<javax.json.version>1.1.3</javax.json.version>
 	<commons.beanutils.version>1.9.3</commons.beanutils.version>
   </properties>
@@ -60,7 +58,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.6.RELEASE</version>
+    <version>2.2.1.RELEASE</version>
   </parent>
 
   <scm>
@@ -261,36 +259,20 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!--JUnit Jupiter Engine to depend on the JUnit5 engine and JUnit 5 API -->
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>${rest-assured.version}</version>
       <scope>test</scope>
 	</dependency>
 	<dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>json-path</artifactId>
-      <version>${rest-assured.version}</version>
       <scope>test</scope>
 	</dependency>
 	<dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>json-schema-validator</artifactId>
-      <version>${rest-assured.version}</version>
       <scope>test</scope>
 	</dependency>
     <dependency>
@@ -320,6 +302,7 @@
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
           <includeSystemScope>true</includeSystemScope>
+          <fork>false</fork>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/18020

-Updated spring boot version to 2.2.1.
-Removed unnecessary rest-assured version.
-Added fork:true config to spring boot plugin so launch arguments still
work through eclipse.
-Removed explicit JUnit dependency because SpringBoot uses JUnit 5 now.